### PR TITLE
Integrate misaminotbp bot and debug placement

### DIFF
--- a/src/features/misamino.js
+++ b/src/features/misamino.js
@@ -192,8 +192,8 @@ export class MisaMinoBot {
                         // Garbage cell without explicit piece type; mark as garbage/occupied
                         cellValue = "G";
                     } else {
-                        // Fallback occupied cell
-                        cellValue = null;
+                        // Fallback occupied cell: mark as filled for TBP
+                        cellValue = "X";
                     }
                 }
 
@@ -339,9 +339,14 @@ export class MisaMinoBot {
             Game.movement.rotate("CW"); // Rotate clockwise
         }
 
-        // Move piece to target X position
-        Game.falling.location = [targetX, targetY];
-        Game.pixi.setRotationCenterPos(Game.falling.location, Game.falling.piece.name);
+        // Move horizontally toward target X using movement system
+        const currentX = Game.falling.location[0];
+        const dx = targetX - currentX;
+        if (dx > 0) {
+            Game.movement.movePieceSide("RIGHT", dx);
+        } else if (dx < 0) {
+            Game.movement.movePieceSide("LEFT", -dx);
+        }
 
         // Handle spin moves (T-spins, etc.)
         if (spin && spin !== 'none') {


### PR DESCRIPTION
Fix MisaMino bot piece misplacement by correcting TBP board conversion and using the game's movement system for horizontal placement.

The bot previously received an inaccurate board state because occupied cells without explicit piece tokens were sent as `null` (empty) instead of 'X' (occupied). Additionally, directly setting the piece's `location` bypassed TETI's internal collision and kick logic, resulting in pieces landing incorrectly. The updated logic ensures the bot receives a correct board and that piece movements adhere to game mechanics.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bdb417b-ad80-4d6f-b05c-bdb3ce9c0e8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bdb417b-ad80-4d6f-b05c-bdb3ce9c0e8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

